### PR TITLE
fix: missing engine options config info

### DIFF
--- a/CONTRIBUTOR.md
+++ b/CONTRIBUTOR.md
@@ -16,6 +16,7 @@
 - [leoyuan](https://github.com/leoyuan)
 - [liujuping](https://github.com/liujuping)
 - [lqy978599280](https://github.com/lqy978599280)
+- [markyun](https://github.com/markyun)
 - [mark-ck](https://github.com/mark-ck)
 - [mochen666](https://github.com/mochen666)
 - [tsy77](https://github.com/tsy77)


### PR DESCRIPTION
fix: missing engine options config info